### PR TITLE
fix: defer provider configuration validation to resource usage

### DIFF
--- a/keboola/provider.go
+++ b/keboola/provider.go
@@ -91,20 +91,12 @@ func (p *KeboolaProvider) Configure(ctx context.Context, req provider.ConfigureR
 	} else {
 		token = config.Token.ValueString()
 	}
-	// Validate that we have the required values
-	if hostnameSuffix == "" {
-		resp.Diagnostics.AddError(
-			"Unable to create client",
-			"Hostname suffix is required. Set it in the provider configuration or via KBC_HOSTNAME_SUFFIX environment variable.",
-		)
-		return
-	}
-
-	if token == "" {
-		resp.Diagnostics.AddError(
-			"Unable to create client",
-			"Token is required. Set it in the provider configuration or via KBC_MANAGE_TOKEN environment variable.",
-		)
+	// If hostname or token are not configured, skip client creation.
+	// This allows the provider to be instantiated without credentials
+	// (e.g., in for_each provider configurations where some instances
+	// don't need the provider). Resources will receive nil ProviderData
+	// and return early in their Configure methods.
+	if hostnameSuffix == "" || token == "" {
 		return
 	}
 


### PR DESCRIPTION
## Release Notes 
Defer provider configuration validation from provider instantiation time to resource usage time. When `hostname_suffix` or `token` are not set, the provider now silently skips client creation instead of returning an error. Resources already handle `nil` ProviderData by returning early in their `Configure` methods, so unconfigured provider instances are safe — they only fail if a resource actually tries to use them.

## Plans for customer communication
None.

## Impact analysis
This is a common practice among Terraform/OpenTofu providers (AWS, GCP, Azure) — they allow unconfigured provider instances and only fail when a resource attempts to use them. This is required for our use in the Snowflake accounts pipeline (`keboola/infrastructure`), which uses OpenTofu's `for_each` dynamic provider configuration. Every module instance must receive a `keboola-management` provider, but some accounts (e.g., private single-tenant stacks) don't have Management API access and will never create resources from this provider.

The schema already declares both `hostname_suffix` and `token` as `Optional`, but the `Configure()` function was eagerly enforcing them as required — making the documented optionality a lie. This fix aligns runtime behavior with the schema.

No breaking changes — all existing configurations with valid credentials continue to work identically. Only previously-failing configurations (missing token) now succeed silently.

## Change type
Bug fix.

## Justification
OpenTofu's dynamic provider `for_each` requires a provider instance for every module instance, even when that module instance creates no resources from the provider. The eager token validation prevented this pattern.

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)